### PR TITLE
Make profiling safer for dangerous opcodes

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -668,7 +668,6 @@ void execute_loop()
         break;
 
       case op_restore:
-        profile_fail("restore");
         value = perform_restore(find_stream_by_id(inst[0].value), FALSE);
         if (value == 0) {
           /* We've succeeded, and the stack now contains the callstub
@@ -690,7 +689,6 @@ void execute_loop()
         break;
 
       case op_restoreundo:
-        profile_fail("restoreundo");
         value = perform_restoreundo();
         if (value == 0) {
           /* We've succeeded, and the stack now contains the callstub

--- a/glulxe.h
+++ b/glulxe.h
@@ -291,6 +291,7 @@ extern void setup_profile(strid_t stream, char *filename);
 extern int init_profile(void);
 extern void profile_set_call_counts(int flag);
 #if VM_PROFILING
+extern int profiling_active;
 extern glui32 profile_opcount;
 #define profile_tick() (profile_opcount++)
 extern void profile_in(glui32 addr, glui32 stackuse, int accel);

--- a/glulxe.h
+++ b/glulxe.h
@@ -296,7 +296,12 @@ extern glui32 profile_opcount;
 #define profile_tick() (profile_opcount++)
 extern void profile_in(glui32 addr, glui32 stackuse, int accel);
 extern void profile_out(glui32 stackuse);
-extern void profile_fail(char *reason);
+/* profile_fail() is now a macro to more easily exit the exec loop */
+#define profile_fail(reason) \
+  if (profiling_active) { \
+      nonfatal_warning_2("Aborting profile: unable to handle operation", reason); \
+      done_executing = TRUE; \
+      break; }
 extern void profile_quit(void);
 #else /* VM_PROFILING */
 #define profile_tick()         (0)

--- a/profile.c
+++ b/profile.c
@@ -9,7 +9,7 @@ information as the Glulx program executes.
 
 The profiling code is not smart about VM operations that rearrange the
 call stack. In fact, it's downright stupid. To prevent errors @restore
-and @restoreundo will fail, while @restart and @throw will kill the
+and @restoreundo will fail, while @restart and @throw will abort the
 interpreter.
 
 On a normal VM exit (end of top-level routine or @quit), the profiler
@@ -353,17 +353,6 @@ void profile_out(glui32 stackuse)
   fra->parent = NULL;
 
   glulx_free(fra);
-}
-
-/* ### throw/catch */
-/* ### restore/restore_undo/restart */
-
-void profile_fail(char *reason)
-{
-  if (!profiling_active)
-    return;
-
-  fatal_error_2("Profiler: unable to handle operation", reason);
 }
 
 void profile_quit()

--- a/profile.c
+++ b/profile.c
@@ -8,8 +8,9 @@ If compiled in, these functions maintain a collection of profiling
 information as the Glulx program executes.
 
 The profiling code is not smart about VM operations that rearrange the
-call stack. In fact, it's downright stupid. @restart, @restore,
-@restoreundo, or @throw will kill the interpreter.
+call stack. In fact, it's downright stupid. To prevent errors @restore
+and @restoreundo will fail, while @restart and @throw will kill the
+interpreter.
 
 On a normal VM exit (end of top-level routine or @quit), the profiler
 writes out a data file, using the filename you provided with the 
@@ -87,7 +88,7 @@ by the entire program; its max_depth is zero.
 #include <sys/time.h>
 
 /* Set if the --profile switch is used. */
-static int profiling_active = FALSE;
+int profiling_active = FALSE;
 static char *profiling_filename = NULL;
 static strid_t profiling_stream = NULL;
 static int profiling_call_counts = FALSE;

--- a/serial.c
+++ b/serial.c
@@ -222,6 +222,13 @@ glui32 perform_restoreundo()
   glui32 res, val;
   glui32 heapsumlen = 0;
   glui32 *heapsumarr = NULL;
+  
+  /* If profiling is enabled and active then fail */
+  #if VM_PROFILING
+  if (profiling_active)
+    return 1;
+  #endif /* VM_PROFILING */
+
 
   if (undo_chain_size == 0 || undo_chain_num == 0)
     return 1;
@@ -428,6 +435,12 @@ glui32 perform_restore(strid_t str, int fromshell)
   glui32 filestart, filelen;
   glui32 heapsumlen = 0;
   glui32 *heapsumarr = NULL;
+  
+  /* If profiling is enabled and active then fail */
+  #if VM_PROFILING
+  if (profiling_active)
+    return 1;
+  #endif /* VM_PROFILING */
 
   stream_get_iosys(&val, &lx);
   if (val != 2 && !fromshell) {


### PR DESCRIPTION
Fixes #10 
@restore and @restoreundo will fail
@throw and @restart will abort with a warning message but complete the profile output