### PR TITLE
Fix "variable may be uninitialized when used here" warnings 

### DIFF
--- a/operand.c
+++ b/operand.c
@@ -298,7 +298,7 @@ void parse_operands(oparg_t *args, operandlist_t *oplist)
   int numops = oplist->num_ops;
   int argsize = oplist->arg_size;
   glui32 modeaddr = pc;
-  int modeval;
+  int modeval=0;
 
   pc += (numops+1) / 2;
 

--- a/serial.c
+++ b/serial.c
@@ -117,7 +117,7 @@ glui32 perform_saveundo()
 {
   dest_t dest;
   glui32 res;
-  glui32 memstart, memlen, heapstart, heaplen, stackstart, stacklen;
+  glui32 memstart = 0, memlen = 0, heapstart = 0, heaplen = 0, stackstart = 0, stacklen = 0;
 
   /* The format for undo-saves is simpler than for saves on disk. We
      just have a memory chunk, a heap chunk, and a stack chunk, in
@@ -219,7 +219,7 @@ glui32 perform_saveundo()
 glui32 perform_restoreundo()
 {
   dest_t dest;
-  glui32 res, val;
+  glui32 res, val = 0;
   glui32 heapsumlen = 0;
   glui32 *heapsumarr = NULL;
 
@@ -291,7 +291,7 @@ glui32 perform_save(strid_t str)
   dest_t dest;
   int ix;
   glui32 res, lx, val;
-  glui32 memstart, memlen, stackstart, stacklen, heapstart, heaplen;
+  glui32 memstart=0, memlen=0, stackstart=0, stacklen=0, heapstart=0, heaplen=0;
   glui32 filestart=0, filelen;
 
   stream_get_iosys(&val, &lx);
@@ -431,7 +431,7 @@ glui32 perform_restore(strid_t str, int fromshell)
   dest_t dest;
   int ix;
   glui32 lx, res, val;
-  glui32 filestart, filelen;
+  glui32 filestart, filelen = 0;
   glui32 heapsumlen = 0;
   glui32 *heapsumarr = NULL;
 

--- a/serial.c
+++ b/serial.c
@@ -1185,7 +1185,7 @@ static glui32 read_stackstate(dest_t *dest, glui32 chunklen, int portable)
 
 glui32 perform_verify()
 {
-  glui32 len, checksum, newlen;
+  glui32 len, checksum=0, newlen;
   unsigned char buf[4];
   glui32 val, newsum, ix;
 


### PR DESCRIPTION
These are encountered when compiling using Xcode 13 and the included Clang version (Most likely the `-Wconditional-uninitialized` flag that Xcode really wants you to use).