### PR TITLE
Use OS RNG functionality on Windows

### DIFF
--- a/osdepend.c
+++ b/osdepend.c
@@ -34,6 +34,38 @@
 static glui32 mt_random(void);
 static void mt_seed_random(glui32 seed);
 
+#ifdef OS_STDC
+
+#include <time.h>
+#include <stdlib.h>
+
+/* Allocate a chunk of memory. */
+void *glulx_malloc(glui32 len)
+{
+  return malloc(len);
+}
+
+/* Resize a chunk of memory. This must follow ANSI rules: if the
+   size-change fails, this must return NULL, but the original chunk
+   must remain unchanged. */
+void *glulx_realloc(void *ptr, glui32 len)
+{
+  return realloc(ptr, len);
+}
+
+/* Deallocate a chunk of memory. */
+void glulx_free(void *ptr)
+{
+  free(ptr);
+}
+
+/* Use our Mersenne Twister as the native RNG, seeded
+   from the clock. */
+#define RAND_SET_SEED() (mt_seed_random(time(NULL)))
+#define RAND_GET() (mt_random())
+
+#endif /* OS_STDC */
+
 #ifdef OS_UNIX
 
 #include <time.h>
@@ -46,7 +78,7 @@ void *glulx_malloc(glui32 len)
 }
 
 /* Resize a chunk of memory. This must follow ANSI rules: if the
-   size-change fails, this must return NULL, but the original chunk 
+   size-change fails, this must return NULL, but the original chunk
    must remain unchanged. */
 void *glulx_realloc(void *ptr, glui32 len)
 {
@@ -81,7 +113,7 @@ void *glulx_malloc(glui32 len)
 }
 
 /* Resize a chunk of memory. This must follow ANSI rules: if the
-   size-change fails, this must return NULL, but the original chunk 
+   size-change fails, this must return NULL, but the original chunk
    must remain unchanged. */
 void *glulx_realloc(void *ptr, glui32 len)
 {
@@ -115,8 +147,8 @@ static glui32 msc_random()
 
 #else /* Other Windows compilers */
 
-/* Use our Mersenne Twister as the native RNG, but seed it from
-   the clock. */
+/* Use our Mersenne Twister as the native RNG, seeded
+   from the clock. */
 #define RAND_SET_SEED() (mt_seed_random(time(NULL)))
 #define RAND_GET() (mt_random())
 

--- a/osdepend.c
+++ b/osdepend.c
@@ -65,7 +65,7 @@ void glulx_free(void *ptr)
 
 #endif /* OS_UNIX */
 
-#ifdef WIN32
+#ifdef OS_WINDOWS
 
 #include <time.h>
 #include <stdlib.h>
@@ -98,7 +98,7 @@ __declspec(dllimport) unsigned long __stdcall GetTickCount(void);
 #define RAND_SET_SEED() (mt_seed_random(GetTickCount() ^ time(NULL)))
 #define RAND_GET() (mt_random())
 
-#endif /* WIN32 */
+#endif /* OS_WINDOWS */
 
 
 /* If no native RNG is defined above, use the Mersenne implementation. */


### PR DESCRIPTION
I had hoped this would just be a few lines change, but it grew ...

* I've changed the preprocessor symbol enabling the Windows specific code from WIN32 (defined by most Windows compilers) to OS_WINDOWS, so you only get the Windows specific code if that's what you actually ask for.
* In OS_WINDOWS there is now a Visual C++ specific call to Windows' internal RNG.

Slightly more controversially, I have also added a new section to osdepend.c, under the preprocessor symbol OS_STDC. This addresses what the earlier RNG related changes did, but rather more cleanly. The Inform 7 test harness needs a Glulxe that builds with the same RNG on all platforms, and doesn't have any platform dependencies. The previous change did that for OS_UNIX, but that was less elegant than it could be. This introduces what we actually need: a way to compile Glulxe using only C99 functions, with a single RNG.