### PR TITLE
Encode double NaNs with a zero payload

### DIFF
--- a/float.c
+++ b/float.c
@@ -252,7 +252,7 @@ void encode_double(gfloat64 val, glui32 *reshi, glui32 *reslo)
 
  NotANumber:
     *reshi = sign | 0x7FF80000;
-    *reslo = 0x00000001;
+    *reslo = 0x00000000;
     return;
 }
 


### PR DESCRIPTION
This mostly resolves #40 in quick-and-dirty fashion. It doesn't propagate payloads the way IEEE 754-2019 recommends, but it does meet all of WebAssembly's requirements, and therefore all of Wasm2Glulx's requirements.