### PR TITLE
Handle failing to allocate memory for the cache when SERIALIZE_CACHE_RAM is defined

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -88,13 +88,14 @@ int init_serial()
   {
     glui32 len = (endmem - ramstart);
     glui32 res;
-    ramcache = (unsigned char *)glulx_malloc(sizeof(unsigned char *) * len);
-    if (!ramcache)
-      return FALSE;
-    glk_stream_set_position(gamefile, gamefile_start+ramstart, seekmode_Start);
-    res = glk_get_buffer_stream(gamefile, (char *)ramcache, len);
-    if (res != len)
-      return FALSE;
+    /* If alloc fails, will just fall back to reading game stream */
+    ramcache = (unsigned char *)glulx_malloc(sizeof(unsigned char) * len);
+    if (ramcache) {
+      glk_stream_set_position(gamefile, gamefile_start+ramstart, seekmode_Start);
+      res = glk_get_buffer_stream(gamefile, (char *)ramcache, len);
+      if (res != len)
+        return FALSE;
+    }
   }
 #endif /* SERIALIZE_CACHE_RAM */
 
@@ -809,7 +810,11 @@ static glui32 write_memstate(dest_t *dest)
   runlen = 0;
 
 #ifdef SERIALIZE_CACHE_RAM
-  cachepos = 0;
+  if (ramcache) {
+    cachepos = 0;
+  } else {
+    glk_stream_set_position(gamefile, gamefile_start+ramstart, seekmode_Start);
+  }
 #else /* SERIALIZE_CACHE_RAM */
   glk_stream_set_position(gamefile, gamefile_start+ramstart, seekmode_Start);
 #endif /* SERIALIZE_CACHE_RAM */
@@ -818,8 +823,15 @@ static glui32 write_memstate(dest_t *dest)
     ch = Mem1(pos);
     if (pos < endgamefile) {
 #ifdef SERIALIZE_CACHE_RAM
-      val = ramcache[cachepos];
-      cachepos++;
+      if (ramcache) {
+        val = ramcache[cachepos];
+        cachepos++;
+      } else {
+        val = glk_get_char_stream(gamefile);
+        if (val == -1) {
+          fatal_error("The game file ended unexpectedly while saving.");
+        }
+      }
 #else /* SERIALIZE_CACHE_RAM */
       val = glk_get_char_stream(gamefile);
       if (val == -1) {
@@ -882,7 +894,11 @@ static glui32 read_memstate(dest_t *dest, glui32 chunklen)
   runlen = 0;
 
 #ifdef SERIALIZE_CACHE_RAM
-  cachepos = 0;
+  if (ramcache) {
+    cachepos = 0;
+  } else {
+    glk_stream_set_position(gamefile, gamefile_start+ramstart, seekmode_Start);
+  }
 #else /* SERIALIZE_CACHE_RAM */
   glk_stream_set_position(gamefile, gamefile_start+ramstart, seekmode_Start);
 #endif /* SERIALIZE_CACHE_RAM */
@@ -890,8 +906,15 @@ static glui32 read_memstate(dest_t *dest, glui32 chunklen)
   for (pos=ramstart; pos<endmem; pos++) {
     if (pos < endgamefile) {
 #ifdef SERIALIZE_CACHE_RAM
-      val = ramcache[cachepos];
-      cachepos++;
+      if (ramcache) {
+        val = ramcache[cachepos];
+        cachepos++;
+      } else {
+        val = glk_get_char_stream(gamefile);
+        if (val == -1) {
+          fatal_error("The game file ended unexpectedly while restoring.");
+        }
+      }
 #else /* SERIALIZE_CACHE_RAM */
       val = glk_get_char_stream(gamefile);
       if (val == -1) {

--- a/vm.c
+++ b/vm.c
@@ -113,7 +113,10 @@ void setup_vm()
   /* Initialize various other things in the terp. */
   init_operands(); 
   init_accel();
-  init_serial();
+  if (!init_serial()) {
+    finalize_vm();
+    fatal_error("Unable to initialize serialization.");
+  }
 
   /* Set up the initial machine state. */
   vm_restart();


### PR DESCRIPTION
I got an email from someone asking about my ancient Commodore Amiga port of Glulxe, which caused me to dig it out and get it to build with Glulxe 0.6.1. That all worked, except that Counterfeit Monkey failed with an error on start-up. When starting up CM restores a saved position from a resource stream, in order to avoid spending time performing initialization calculations, and it was this that was going wrong.

This showed up a number of problems in the SERIALIZE_CACHE_RAM code:

1. The cache allocated is too big: the length is multiplied by sizeof(unsigned char*), when it should be just sizeof(unsigned char).
2. init_serial() returns a boolean, but the return value is not checked, the code just carries on if FALSE is returned.
3. With SERIALIZE_CACHE_RAM defined the cache is used even if the allocation for it failed, using random data.

I could have just fixed the code so that if init_serial() failed the interpreter stopped, but it seemed better to change things so that if the allocation fails then the interpreter carries on, but just uses the old method before SERIALIZE_CACHE_RAM, so that's what I did.